### PR TITLE
Add an empty environments.json file

### DIFF
--- a/environments.json
+++ b/environments.json
@@ -1,0 +1,9 @@
+{
+    "environments": [
+        {
+            "name": "production",
+            "configOverride": {},
+            "gitRef": "master"
+        }
+    ]
+}


### PR DESCRIPTION
The "Create schedule" flow in Dataform Web doesn't currently work if there is no `environments.json` file. Adding this default environments.json file to your repo will mean the the final part of the walkthrough, creating a schedule, will work.